### PR TITLE
Add blurb about current GitHub status

### DIFF
--- a/src/lib/components/DeploymentModals.svelte
+++ b/src/lib/components/DeploymentModals.svelte
@@ -155,7 +155,7 @@
 						}`}
 					>
 						<GitBranch class="h-4 w-4" />
-						Git
+						Git (BETA)
 					</button>
 					<button
 						type="button"
@@ -207,6 +207,8 @@
 					{/if}
 
 					{#if createActiveTab === 'git'}
+						<h3 class="text-lg font-semibold">This feature is in beta at the moment</h3>
+						<p class="text-zinc-400">For now though, you can use <a href="/workflow.yml">this</a> GitHub Actions workflow to create a new Docker Image from the Dockerfile in your repository on every push, then publish the resulting image to GitHub. The resulting package <i>will</i> work on TYSONCLOUD</p>
 						<input type="hidden" name="deployment_type" value="git" />
 						<div class="space-y-2">
 							<label for="git-url" class="block text-sm font-medium"> Repository URL </label>

--- a/static/workflow.yml
+++ b/static/workflow.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
 

--- a/static/workflow.yml
+++ b/static/workflow.yml
@@ -1,0 +1,40 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR just makes it clear that Git projects on TYSONCLOUD are in beta, and also offers a workaround for the time being. I've tested the attached workflow with somebody else's project, and it does indeed work with TYSONCLOUD.