### PR TITLE
feat: add frontend for config files

### DIFF
--- a/frontend/src/lib/api/project-config.ts
+++ b/frontend/src/lib/api/project-config.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { api } from "./client";
+import type { ProjectConfigApplyRequest } from "./types";
+
+export function useApplyProjectConfig(projectId: string) {
+  return useMutation({
+    mutationFn: (body: ProjectConfigApplyRequest) =>
+      api.post<void>(`/projects/${projectId}/config`, body),
+  });
+}

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -78,4 +78,9 @@ export type VolumeCreateRequest = {
 export type ApiError = {
   error?: string;
   message?: string;
+  issues?: { line?: number; message: string }[];
+};
+
+export type ProjectConfigApplyRequest = {
+  content: string;
 };

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SignInSplatRouteImport } from './routes/sign-in/$'
 import { Route as SignUpIndexRouteImport } from './routes/sign-up/index'
 import { Route as SignUpSplatRouteImport } from './routes/sign-up/$'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
+import { Route as ProjectsProjectIdConfigRouteImport } from './routes/projects/$projectId/config'
 import { Route as ProjectsProjectIdEditRouteImport } from './routes/projects/$projectId/edit'
 import { Route as ProjectsProjectIdDatabasesNewRouteImport } from './routes/projects/$projectId/databases/new'
 import { Route as ProjectsProjectIdServicesNewRouteImport } from './routes/projects/$projectId/services/new'
@@ -89,6 +90,11 @@ const ProjectsProjectIdIndexRoute = ProjectsProjectIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
+const ProjectsProjectIdConfigRoute = ProjectsProjectIdConfigRouteImport.update({
+  id: '/config',
+  path: '/config',
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
+} as any)
 const ProjectsProjectIdEditRoute = ProjectsProjectIdEditRouteImport.update({
   id: '/edit',
   path: '/edit',
@@ -143,6 +149,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/': typeof DashboardIndexRoute
   '/sign-in/': typeof SignInIndexRoute
   '/sign-up/': typeof SignUpIndexRoute
+  '/projects/$projectId/config': typeof ProjectsProjectIdConfigRoute
   '/projects/$projectId/edit': typeof ProjectsProjectIdEditRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/databases/new': typeof ProjectsProjectIdDatabasesNewRoute
@@ -160,6 +167,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof DashboardIndexRoute
   '/sign-in': typeof SignInIndexRoute
   '/sign-up': typeof SignUpIndexRoute
+  '/projects/$projectId/config': typeof ProjectsProjectIdConfigRoute
   '/projects/$projectId/edit': typeof ProjectsProjectIdEditRoute
   '/projects/$projectId': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/databases/new': typeof ProjectsProjectIdDatabasesNewRoute
@@ -182,6 +190,7 @@ export interface FileRoutesById {
   '/dashboard/': typeof DashboardIndexRoute
   '/sign-in/': typeof SignInIndexRoute
   '/sign-up/': typeof SignUpIndexRoute
+  '/projects/$projectId/config': typeof ProjectsProjectIdConfigRoute
   '/projects/$projectId/edit': typeof ProjectsProjectIdEditRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/databases/new': typeof ProjectsProjectIdDatabasesNewRoute
@@ -205,6 +214,7 @@ export interface FileRouteTypes {
     | '/dashboard/'
     | '/sign-in/'
     | '/sign-up/'
+    | '/projects/$projectId/config'
     | '/projects/$projectId/edit'
     | '/projects/$projectId/'
     | '/projects/$projectId/databases/new'
@@ -222,6 +232,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/sign-in'
     | '/sign-up'
+    | '/projects/$projectId/config'
     | '/projects/$projectId/edit'
     | '/projects/$projectId'
     | '/projects/$projectId/databases/new'
@@ -243,6 +254,7 @@ export interface FileRouteTypes {
     | '/dashboard/'
     | '/sign-in/'
     | '/sign-up/'
+    | '/projects/$projectId/config'
     | '/projects/$projectId/edit'
     | '/projects/$projectId/'
     | '/projects/$projectId/databases/new'
@@ -347,6 +359,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
+    '/projects/$projectId/config': {
+      id: '/projects/$projectId/config'
+      path: '/config'
+      fullPath: '/projects/$projectId/config'
+      preLoaderRoute: typeof ProjectsProjectIdConfigRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
     '/projects/$projectId/edit': {
       id: '/projects/$projectId/edit'
       path: '/edit'
@@ -442,6 +461,7 @@ const SignUpRouteRouteWithChildren = SignUpRouteRoute._addFileChildren(
 )
 
 interface ProjectsProjectIdRouteRouteChildren {
+  ProjectsProjectIdConfigRoute: typeof ProjectsProjectIdConfigRoute
   ProjectsProjectIdEditRoute: typeof ProjectsProjectIdEditRoute
   ProjectsProjectIdIndexRoute: typeof ProjectsProjectIdIndexRoute
   ProjectsProjectIdDatabasesNewRoute: typeof ProjectsProjectIdDatabasesNewRoute
@@ -454,6 +474,7 @@ interface ProjectsProjectIdRouteRouteChildren {
 
 const ProjectsProjectIdRouteRouteChildren: ProjectsProjectIdRouteRouteChildren =
   {
+    ProjectsProjectIdConfigRoute: ProjectsProjectIdConfigRoute,
     ProjectsProjectIdEditRoute: ProjectsProjectIdEditRoute,
     ProjectsProjectIdIndexRoute: ProjectsProjectIdIndexRoute,
     ProjectsProjectIdDatabasesNewRoute: ProjectsProjectIdDatabasesNewRoute,

--- a/frontend/src/routes/projects/$projectId/config.tsx
+++ b/frontend/src/routes/projects/$projectId/config.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import { FileCode } from "lucide-react";
+import { useApplyProjectConfig } from "@/lib/api/project-config";
+import { serviceKeys } from "@/lib/api/services";
+import { databaseKeys } from "@/lib/api/databases";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ApiRequestError } from "@/lib/api/client";
+
+export const Route = createFileRoute("/projects/$projectId/config")({
+  component: ProjectConfigPage,
+});
+
+const EXAMPLE_TOML = `# Define the resources this project should have, then apply.
+# This runs once — it creates what's listed below, it doesn't sync or delete.
+
+[[services]]
+name = "web"
+image = "myorg/web:latest"
+port = 3000
+
+  [services.volume]
+  mount_path = "/data"
+  storage_gb = 10
+
+[[services]]
+name = "worker"
+image = "myorg/worker:latest"
+port = 8080
+
+[[databases]]
+name = "primary"
+engine = "postgres"
+storage_gb = 20
+`;
+
+function ProjectConfigPage() {
+  const { projectId } = Route.useParams();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const applyConfig = useApplyProjectConfig(projectId);
+
+  const [content, setContent] = useState(EXAMPLE_TOML);
+
+  const issues =
+    applyConfig.error instanceof ApiRequestError ? applyConfig.error.body?.issues : undefined;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+      <Link
+        to="/projects/$projectId"
+        params={{ projectId }}
+        className="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-accent)]"
+      >
+        ← Back to project
+      </Link>
+
+      <div className="mt-4 mb-2 flex items-center gap-2">
+        <FileCode className="h-5 w-5 text-[var(--color-text-faint)]" />
+        <h1 className="font-mono text-2xl font-bold">Apply config</h1>
+      </div>
+      <p className="mb-6 text-sm text-[var(--color-text-muted)]">
+        Define services, databases, and volumes as TOML and apply them in one shot. This creates
+        resources — it's a one-time action, not a saved file.
+      </p>
+
+      <form
+        className="space-y-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          applyConfig.mutate(
+            { content },
+            {
+              onSuccess: () => {
+                qc.invalidateQueries({ queryKey: serviceKeys.byProject(projectId) });
+                qc.invalidateQueries({ queryKey: databaseKeys.byProject(projectId) });
+                navigate({ to: "/projects/$projectId", params: { projectId } });
+              },
+            },
+          );
+        }}
+      >
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          spellCheck={false}
+          rows={24}
+          className="text-sm leading-relaxed"
+        />
+
+        {applyConfig.error && (
+          <div className="rounded-md border border-[var(--color-bad)] bg-[var(--color-bad-soft)] p-3">
+            <p className="text-sm text-[var(--color-bad)]">{applyConfig.error.message}</p>
+            {issues && issues.length > 0 && (
+              <ul className="mt-2 space-y-1 text-xs text-[var(--color-bad)]">
+                {issues.map((issue, i) => (
+                  <li key={i}>
+                    {issue.line != null && <span className="font-mono">line {issue.line}: </span>}
+                    {issue.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 border-t border-[var(--color-border)] pt-5">
+          <Button type="submit" disabled={applyConfig.isPending}>
+            {applyConfig.isPending ? "Applying…" : "Apply config"}
+          </Button>
+          <Link to="/projects/$projectId" params={{ projectId }}>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </Link>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/frontend/src/routes/projects/$projectId/config.tsx
+++ b/frontend/src/routes/projects/$projectId/config.tsx
@@ -83,6 +83,7 @@ function ProjectConfigPage() {
         }}
       >
         <Textarea
+          id="config"
           value={content}
           onChange={(e) => setContent(e.target.value)}
           spellCheck={false}

--- a/frontend/src/routes/projects/$projectId/index.tsx
+++ b/frontend/src/routes/projects/$projectId/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Database as DatabaseIcon, Pencil, Plus, Server } from "lucide-react";
+import { Database as DatabaseIcon, FileCode, Pencil, Plus, Server } from "lucide-react";
 import { useProject } from "@/lib/api/projects";
 import { useDeleteService, useServices } from "@/lib/api/services";
 import { useDatabases, useDeleteDatabase } from "@/lib/api/databases";
@@ -52,6 +52,14 @@ function ProjectDetail() {
           className="text-[var(--color-text-faint)] hover:text-[var(--color-accent)]"
         >
           <Pencil className="h-4 w-4" />
+        </Link>
+        <Link
+          to="/projects/$projectId/config"
+          params={{ projectId }}
+          aria-label="Apply project config"
+          className="text-[var(--color-text-faint)] hover:text-[var(--color-accent)]"
+        >
+          <FileCode className="h-4 w-4" />
         </Link>
       </div>
       <p className="mt-1 text-base text-[var(--color-text-muted)]">


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Apply project config” option to project pages.
  * Added an editable TOML configuration page for defining services, databases, and volumes.
  * Configurations can be submitted, with users returned to the project page after successful application.
  * Added validation feedback, including line-specific configuration errors.
  * Submission is disabled while changes are being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->