### PR TITLE
feat: add bulk delete API for services and databases

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -124,5 +124,6 @@ export const api = {
     request<T>(path, { method: "POST", body: body ? JSON.stringify(body) : undefined }),
   put: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: "PUT", body: body ? JSON.stringify(body) : undefined }),
-  delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+  delete: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: "DELETE", body: body ? JSON.stringify(body) : undefined }),
 };

--- a/frontend/src/lib/api/databases.ts
+++ b/frontend/src/lib/api/databases.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./client";
-import type { Database, DatabaseCreateRequest, DatabaseUpdateRequest } from "./types";
+import type { BulkDeleteResponse, Database, DatabaseCreateRequest, DatabaseUpdateRequest } from "./types";
 
 export const databaseKeys = {
   byProject: (projectId: string) => ["projects", projectId, "databases"] as const,
@@ -49,6 +49,15 @@ export function useDeleteDatabase(projectId: string) {
   return useMutation({
     mutationFn: (databaseId: string) =>
       api.delete<void>(`/projects/${projectId}/databases/${databaseId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: databaseKeys.byProject(projectId) }),
+  });
+}
+
+export function useDeleteDatabases(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (databaseIds: string[]) =>
+      api.delete<BulkDeleteResponse>(`/projects/${projectId}/databases`, { ids: databaseIds }),
     onSuccess: () => qc.invalidateQueries({ queryKey: databaseKeys.byProject(projectId) }),
   });
 }

--- a/frontend/src/lib/api/services.ts
+++ b/frontend/src/lib/api/services.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./client";
-import type { Service, ServiceCreateRequest, ServiceUpdateRequest } from "./types";
+import type { BulkDeleteResponse, Service, ServiceCreateRequest, ServiceUpdateRequest } from "./types";
 
 export const serviceKeys = {
   byProject: (projectId: string) => ["projects", projectId, "services"] as const,
@@ -49,6 +49,15 @@ export function useDeleteService(projectId: string) {
   return useMutation({
     mutationFn: (serviceId: string) =>
       api.delete<void>(`/projects/${projectId}/services/${serviceId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: serviceKeys.byProject(projectId) }),
+  });
+}
+
+export function useDeleteServices(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (serviceIds: string[]) =>
+      api.delete<BulkDeleteResponse>(`/projects/${projectId}/services`, { ids: serviceIds }),
     onSuccess: () => qc.invalidateQueries({ queryKey: serviceKeys.byProject(projectId) }),
   });
 }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -81,6 +81,11 @@ export type ApiError = {
   issues?: { line?: number; message: string }[];
 };
 
+export type BulkDeleteResponse = {
+  deleted: string[];
+  failed: { id: string; error: string }[];
+};
+
 export type ProjectConfigApplyRequest = {
   content: string;
 };


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk deletion for databases and services.
  * Bulk deletion now reports successfully deleted items and any failures.
  * DELETE requests can optionally include a request body.
  * Related data lists refresh automatically after successful bulk deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->